### PR TITLE
Remove factory_girl deprecated gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', '~> 9.1.0'
   gem 'capybara', '~> 2.13'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'ffaker'
   gem 'pronto', require: false
   gem 'pronto-brakeman', require: false


### PR DESCRIPTION
Factory_girl is a pretty neat testing gem, but it's now deprecated because they changed its name. Just changed gems since we'll be using it when creating tests.